### PR TITLE
Fix: Assignment to `const` results in a "no overload" error for `operator=`

### DIFF
--- a/src/BuiltIn/succSymbol.cc
+++ b/src/BuiltIn/succSymbol.cc
@@ -138,7 +138,7 @@ SuccSymbol::makeNatDag64(uint64_t nat)
   //
   unsigned long low = nat & 0xFFFFFFFF;
   unsigned long high = nat >> 32;
-  const mpz_class number(high);
+  mpz_class number(high);
   number = (number << 32) + low;
   return (nat == 0) ? zero : (new S_DagNode(this, number, zero));
 #endif


### PR DESCRIPTION
On some platforms, an assignment to a `const mpz_class` results in a "no overload" error for `operator=` (assignment operator). The error is triggered when it is _not_ true that `SIZEOF_UNSIGNED_LONG == 8`, e.g. on 32-bit architectures.

The context is small enough to reproduce in its entirety here:

```cpp
DagNode*
SuccSymbol::makeNatDag64(uint64_t nat)
{
  DagNode* zero = zeroTerm.getDag();
#if SIZEOF_UNSIGNED_LONG == 8
  return (nat == 0) ? zero : (new S_DagNode(this, static_cast<unsigned long>(nat), zero));
#else
  //
  //	Hack for 32-bit machines.
  //
  unsigned long low = nat & 0xFFFFFFFF;
  unsigned long high = nat >> 32;
  const mpz_class number(high);
  number = (number << 32) + low;
  return (nat == 0) ? zero : (new S_DagNode(this, number, zero));
#endif
}
```

It looks like just a copy+paste error, because `number` doesn't need to be `const` here. Excruciating details are given in the next paragraph, which you're welcome to skip over.

The issue is in the `#else` preprocessor branch, where it is assumed that `unsigned long` is 32 bits. The "hack" is to load the value of the 64-bit parameter `nat` into an `mpz_class` `number` 32 bits at a time by first loading the high 32 bits into the lower 32 bits of `number`, shifting `number` left by 32, and then loading the low 32 bits of `nat` into the now zeroed lower 32 bits of `number`. These steps require at least two assignments to `number`, which is prohibited by the `const`.

The fix is to remove the `const`.