### PR TITLE
fix bug in maude involving integer overflow

### DIFF
--- a/src/FreeTheory/freeTerm.hh
+++ b/src/FreeTheory/freeTerm.hh
@@ -128,7 +128,7 @@ private:
 		  bool eagerContext);
 
   Vector<Term*> argArray;
-  short slotIndex;
+  int slotIndex;
   bool visitedFlag;
 };
 


### PR DESCRIPTION
This PR fixes a bug that can occur if more than 32767 slots are used by a single symbol. If this happens, the index in the field `slotIndex` in `freeTerm.hh` overflows and wraps around to -32768, leading to a crash.