### PR TITLE
Replace some dynamic_casts to FreeTerm with static casts

### DIFF
--- a/src/FreeTheory/freePreNetSemiCompiler.cc
+++ b/src/FreeTheory/freePreNetSemiCompiler.cc
@@ -123,11 +123,16 @@ FreePreNet::setVisitedFlags(const LiveSet& liveSet,
 {
   for (int i : liveSet)
     {
-      if (FreeTerm* f = dynamic_cast<FreeTerm*>(patterns[i].term))
+      Term *t = patterns[i].term;
+      if (t != 0 && t->free())
 	{
-	  Term* t = f->locateSubterm(position);
-	  if (t != 0 && (f = dynamic_cast<FreeTerm*>(t)) != 0)
-	    f->setVisitedFlag(state);
+	  FreeTerm* f = static_cast<FreeTerm*>(t);
+	  t = f->locateSubterm(position);
+	  if (t != 0 && t->free())
+	    {
+	      f = static_cast<FreeTerm*>(t);
+	      f->setVisitedFlag(state);
+	    }
 	}
     }
 }

--- a/src/FreeTheory/freePreNetSubsumption.cc
+++ b/src/FreeTheory/freePreNetSubsumption.cc
@@ -43,18 +43,18 @@ FreePreNet::subsumesWrtReducedFringe(Term* subsumer,
       //	We haven't reached the fringe so we must be in part of the term that
       //	has been matched on our current arc.
       //
-      if (FreeTerm* sf = dynamic_cast<FreeTerm*>(subsumer))
+      if (subsumer != 0 && subsumer->free())
 	{
+          FreeTerm* sf = static_cast<FreeTerm*>(subsumer);
 	  //
 	  //	Current position is not at or below reduced fringe and subsumer
 	  //	subterm has a free symbol on top.
 	  //	Therefore this free symbol will have been matched in
 	  //	the subject and we may be able to do better than naive subsumption.
 	  //
-	  FreeTerm* vf = dynamic_cast<FreeTerm*>(victim);
-	  if (vf != 0)
+	  if (victim != 0 && victim->free())
 	    {
-	      Assert(sf->symbol() == vf->symbol(), "free symbol clash");
+	      Assert(sf->symbol() == victim->symbol(), "free symbol clash");
 	      //
 	      //	victim subterm has the same free symbol on top; check if
 	      //	subsumers arguments subsume victims arguments.
@@ -113,7 +113,7 @@ FreePreNet::subsumesWrtReducedFringe(Term* subsumer,
       //	We haven't reached the fringe so we must be in part of the term that
       //	has been matched on our current arc.
       //
-      if (dynamic_cast<FreeTerm*>(subsumer) != 0)
+      if (subsumer != 0 && subsumer->free())
 	{
 	  Symbol* symbol = subsumer->symbol();
 	  int nrArgs = symbol->arity();

--- a/src/FreeTheory/freeTerm.cc
+++ b/src/FreeTheory/freeTerm.cc
@@ -267,9 +267,9 @@ FreeTerm::locateSubterm(const Vector<int>& position, int backup)
   int nrSteps = position.length() - backup;
   for (int i = 0; i < nrSteps; i++)
     {
-      FreeTerm* f = dynamic_cast<FreeTerm*>(t);
-      if (f == 0)
+      if (t == 0 || !t->free())
 	return 0;
+      FreeTerm* f = static_cast<FreeTerm*>(t);
       int p = position[i];
       if (p >= f->symbol()->arity())
 	return 0;

--- a/src/FreeTheory/freeTerm.cc
+++ b/src/FreeTheory/freeTerm.cc
@@ -83,6 +83,7 @@ FreeTerm::FreeTerm(FreeSymbol* symbol, const Vector<Term*>& arguments)
     argArray[i] = arguments[i];
   slotIndex = -1;
   visitedFlag = false;
+  markFree();
 }
 
 FreeTerm::FreeTerm(const FreeTerm& original, FreeSymbol* symbol, SymbolMap* translator)
@@ -94,6 +95,7 @@ FreeTerm::FreeTerm(const FreeTerm& original, FreeSymbol* symbol, SymbolMap* tran
     argArray[i] = original.argArray[i]->deepCopy(translator);
   slotIndex = -1;
   visitedFlag = false;
+  markFree();
 }
 
 FreeTerm::~FreeTerm()

--- a/src/FreeTheory/freeTerm.cc
+++ b/src/FreeTheory/freeTerm.cc
@@ -285,12 +285,12 @@ FreeTerm::locateSubterm2(Vector<int>& position)
   int nrSteps = position.length();
   for (int i = 0; i < nrSteps; i++)
     {
-      FreeTerm* f = dynamic_cast<FreeTerm*>(t);
-      if (f == 0)
+      if (t == 0 || !t->free())
 	{
 	  position.contractTo(i);
 	  return t;
 	}
+      FreeTerm* f = static_cast<FreeTerm*>(t);
       int p = position[i];
       if (p >= f->symbol()->arity())
 	{

--- a/src/FreeTheory/freeTerm.cc
+++ b/src/FreeTheory/freeTerm.cc
@@ -314,12 +314,18 @@ FreeTerm::findActiveSlots(NatSet& slots)
   bool active = false;
   for (int i = 0; i < nrArgs; i++)
     {
-      FreeTerm* f = dynamic_cast<FreeTerm*>(argArray[i]);
-      if (f != 0 && f->visitedFlag)
+      Term *t = argArray[i];
+      if (t != 0 && t->free())
 	{
-	  f->findActiveSlots(slots);
-	  if (f->getSaveIndex() != NONE)
-	    active = true;
+	  FreeTerm* f = static_cast<FreeTerm*>(t);
+	  if (f->visitedFlag)
+	    {
+	      f->findActiveSlots(slots);
+	      if (f->getSaveIndex() != NONE)
+	        active = true;
+	    }
+          else
+            active = true;
 	}
       else
 	active = true;

--- a/src/Interface/term.hh
+++ b/src/Interface/term.hh
@@ -64,6 +64,7 @@ public:
   Symbol* symbol() const;
   bool ground() const;
   bool stable() const;
+  bool free() const;
   const NatSet& occursBelow() const;
   const NatSet& occursInContext() const;
   const PointerSet& collapseSymbols() const;
@@ -242,6 +243,7 @@ protected:
   void addCollapseSymbols(const PointerSet& symbols);
   void setHashValue(unsigned int value);
   void setSaveIndex(int index);
+  void markFree();
   
 private:
   enum Flags
@@ -260,7 +262,11 @@ private:
     //	never to to return a matching subproblem when all the terms variables
     //	are already bound.
     //
-    HONORS_GROUND_OUT_MATCH = 4
+    HONORS_GROUND_OUT_MATCH = 4,
+    //
+    // A subterm is free if its symbol is part of the free theory.
+    //
+    FREE = 8
   };
 
   static bool commonWithOtherPatterns(Vector<Term*>& patterns, int excluded, Symbol* symbol);
@@ -308,6 +314,18 @@ inline bool
 Term::stable() const
 {
   return flags & STABLE;
+}
+
+inline bool
+Term::free() const
+{
+  return flags & FREE;
+}
+
+inline void
+Term::markFree()
+{
+  flags |= FREE;
 }
 
 inline const NatSet&


### PR DESCRIPTION
In cases where the code in FreePreNet::buildNet and FreePreNet::semiCompile are particularly slow, these changes have shown a reduction in wall time of over 50%.