### PR TITLE
use std::map<int, LiveSet> instead of Vector<LiveSet>

### DIFF
--- a/src/FreeTheory/freePreNet.cc
+++ b/src/FreeTheory/freePreNet.cc
@@ -221,8 +221,7 @@ FreePreNet::makeNode(const LiveSet& liveSet,
       //	prevents a quadratic blow up on certain examples with
       //	huge pattern set.
       //
-      int totalSymbols = topSymbol->getModule()->getSymbols().size();
-      Vector<LiveSet> liveSets(totalSymbols);
+      std::map<int, LiveSet> liveSets;
       LiveSet defaultLiveSet;
       partitionLiveSet(liveSet,
 		       positionIndex,
@@ -382,7 +381,7 @@ void
 FreePreNet::partitionLiveSet(const LiveSet& original,
 			     int positionIndex,
 			     const Vector<Arc>& arcs,
-			     Vector<LiveSet>& liveSets,
+			     std::map<int, LiveSet>& liveSets,
 			     LiveSet& defaultLiveSet)
 {
   const Vector<int>& position = positions.index2Position(positionIndex);  // safe because we won't add new positions

--- a/src/FreeTheory/freePreNet.hh
+++ b/src/FreeTheory/freePreNet.hh
@@ -168,7 +168,7 @@ private:
   void partitionLiveSet(const LiveSet& original,
 			int positionIndex,
 			const Vector<Arc>& arc,
-			Vector<LiveSet>& liveSets,
+			std::map<int, LiveSet>& liveSets,
 			LiveSet& defaultLiveSet);
   bool partiallySubsumed(const LiveSet& liveSet,
 			 int victim,


### PR DESCRIPTION
In cases where the code in FreePreNet::buildNet and FreePreNet::semiCompile are particularly slow, these changes have shown an additional reduction in wall time of 50% when applied together with #14 