### PR TITLE
search for states with more than one successor

### DIFF
--- a/src/Higher/rewriteSequenceSearch.cc
+++ b/src/Higher/rewriteSequenceSearch.cc
@@ -58,6 +58,7 @@ RewriteSequenceSearch::RewriteSequenceSearch(RewritingContext* initial,
   needToTryInitialState = (searchType == ANY_STEPS);
   reachingInitialStateOK = (searchType == AT_LEAST_ONE_STEP || searchType == ONE_STEP);
   normalFormNeeded = (searchType == NORMAL_FORM);
+  criticalPairNeeded = (searchType == CRITICAL_PAIR);
   nextArc = NONE;
 }
 
@@ -119,7 +120,7 @@ RewriteSequenceSearch::findNextInterestingState()
       if (explore == firstDeeperNodeNr)
 	{
 	  ++exploreDepth;
-	  if (normalFormNeeded)
+	  if (normalFormNeeded || criticalPairNeeded)
 	    {
 	      if (maxDepth > 0 && exploreDepth > maxDepth)
 		break;
@@ -144,7 +145,7 @@ RewriteSequenceSearch::findNextInterestingState()
 	      if (exploreDepth == maxDepth)
 		break;  // no point looking for further arcs
 	    }
-	  else
+	  else if (!criticalPairNeeded)
 	    {
 	      if (nextStateNr == nrStates)  // new state reached
 		return nextStateNr;
@@ -166,6 +167,18 @@ RewriteSequenceSearch::findNextInterestingState()
 	  nextArc = NONE;
 	  return explore;
 	}
+      if (criticalPairNeeded && nextArc >= 2)
+	{
+          int nextState = getNextState(explore, 0);
+          for (int arc = 1; arc < nextArc; arc++)
+            {
+              if (nextState != getNextState(explore, arc))
+                {
+	          nextArc = NONE;
+                  return explore;
+                }
+            }
+        }
     }
 
   return NONE;

--- a/src/Higher/rewriteSequenceSearch.hh
+++ b/src/Higher/rewriteSequenceSearch.hh
@@ -58,6 +58,7 @@ private:
   bool needToTryInitialState;
   bool reachingInitialStateOK;
   bool normalFormNeeded;
+  bool criticalPairNeeded;
   MatchSearchState* matchState;
   int stateNr;
 };

--- a/src/Higher/sequenceSearch.hh
+++ b/src/Higher/sequenceSearch.hh
@@ -35,7 +35,8 @@ public:
     ONE_STEP,
     AT_LEAST_ONE_STEP,
     ANY_STEPS,
-    NORMAL_FORM
+    NORMAL_FORM,
+    CRITICAL_PAIR
   };
 };
 

--- a/src/Meta/metaLevel.hh
+++ b/src/Meta/metaLevel.hh
@@ -760,6 +760,8 @@ MetaLevel::downSearchType(DagNode* arg, SequenceSearch::SearchType& searchType)
 	searchType = SequenceSearch::ANY_STEPS;
       else if (qid == Token::encode("!"))
 	searchType = SequenceSearch::NORMAL_FORM;
+      else if (qid == Token::encode("#"))
+	searchType = SequenceSearch::CRITICAL_PAIR;
       else
 	return false;
       return true;

--- a/src/Meta/metaSearch.cc
+++ b/src/Meta/metaSearch.cc
@@ -36,6 +36,8 @@ MetaLevelOpSymbol::downSearchType(DagNode* arg, SequenceSearch::SearchType& sear
 	searchType = SequenceSearch::ANY_STEPS;
       else if (qid == Token::encode("!"))
 	searchType = SequenceSearch::NORMAL_FORM;
+      else if (qid == Token::encode("#"))
+	searchType = SequenceSearch::CRITICAL_PAIR;
       else
 	return false;
       return true;
@@ -186,6 +188,7 @@ MetaLevelOpSymbol::makeSMT_RewriteSequenceSearch(MetaModule* m,
   if (metaLevel->isNat(metaVarNumber) &&
       downSearchType(subject->getArgument(4), searchType) &&
       searchType != SequenceSearch::NORMAL_FORM &&
+      searchType != SequenceSearch::CRITICAL_PAIR &&
       metaLevel->downBound(subject->getArgument(6), maxDepth))
     {
       Term* startTerm;

--- a/src/Mixfix/makeGrammar.cc
+++ b/src/Mixfix/makeGrammar.cc
@@ -149,6 +149,9 @@ MixfixModule::makeComplexProductions()
   rhs[0] = arrowBang;
   parser->insertProduction(SEARCH_CONNECTIVE, rhs, 0, emptyGather,
 			   MixfixParser::NOP, RewriteSequenceSearch::NORMAL_FORM);
+  rhs[0] = arrowAt;
+  parser->insertProduction(SEARCH_CONNECTIVE, rhs, 0, emptyGather,
+			   MixfixParser::NOP, RewriteSequenceSearch::CRITICAL_PAIR);
 
   rhs[0] = MATCH_PAIR;
   parser->insertProduction(MATCH_COMMAND, rhs, 0, gatherAny);

--- a/src/Mixfix/search.cc
+++ b/src/Mixfix/search.cc
@@ -45,6 +45,14 @@ Interpreter::checkSearchRestrictions(SearchKind searchKind,
     case FVU_NARROW:
      {
 	//
+	//	Narrowing does not support =># mode.
+	//
+	if (searchType == SequenceSearch::CRITICAL_PAIR)
+	  {
+	     IssueWarning(*target << ": =># mode is not supported for narrowing.");
+	     return false;
+	  }
+	//
 	//	Narrowing does not support conditions.
 	//
 	if (!condition.empty())
@@ -57,11 +65,12 @@ Interpreter::checkSearchRestrictions(SearchKind searchKind,
     case SMT_SEARCH:
       {
 	//
-	//	SMT search does not support =>! mode since states are symbolic.
+	//	SMT search does not support =>! or =># modes since states are symbolic.
 	//
-	if (searchType == SequenceSearch::NORMAL_FORM)
+	if (searchType == SequenceSearch::NORMAL_FORM ||
+            searchType == SequenceSearch::CRITICAL_PAIR)
 	  {
-	     IssueWarning(*target << ": =>! mode is not supported for searching modulo SMT.");
+	     IssueWarning(*target << ": =>! and =># modes are not supported for searching modulo SMT.");
 	     return false;
 	  }
 	//
@@ -146,7 +155,7 @@ Interpreter::search(const Vector<Token>& bubble,
 
   DagNode* subjectDag = makeDag(initial);
 
-  static const char* searchTypeSymbol[] = { "=>1", "=>+", "=>*", "=>!" };
+  static const char* searchTypeSymbol[] = { "=>1", "=>+", "=>*", "=>!", "=>#" };
   bool showCommand = getFlag(SHOW_COMMAND);
   if (showCommand)
     {

--- a/src/Mixfix/specialTokens.cc
+++ b/src/Mixfix/specialTokens.cc
@@ -45,6 +45,7 @@
   MACRO(arrowPlus, "=>+")
   MACRO(arrowStar, "=>*")
   MACRO(arrowBang, "=>!")
+  MACRO(arrowAt, "=>#")
   MACRO(suchThat, "s.t.")
   MACRO(such, "such")
   MACRO(that, "that")


### PR DESCRIPTION
Of interest to Runtime Verification is the ability to perform a search for states with more than one outbound arc. While we can simulate this functionality by performing a search of a particular depth and then examining and postprocessing the search graph that we get back, this has the undesirable property that it might perform more work than needed, potentially considerably more work. Thus, in the interests of performance, I propose a new search type to add to the `search` command in Maude. This search type searches for states with more than one successor in the same sense that the `=>!` search type searches for states with zero successors.

This is a draft of an attempt to add this functionality to Maude. It is provided in the interests of assisting in the final implementation of such a feature in Maude.